### PR TITLE
Conversion du Makefile pour Nmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,8 @@ drawings = \
 all: directories $(docs) $(drawings)
 
 $(odir)\CN1-ASY-001.pdf: sheet\CN1-ASY-001.pdf
-	pdftk $? cat output $@
 
 $(odir)\CN1-PRT-001.pdf: sheet\CN1-PRT-001.pdf
-	pdftk $? cat output $@
 
 .PHONY: clean directories
 
@@ -56,8 +54,12 @@ sheet:
 #               dwg2pdf  1             pdftk  1
 # drawing/*.dxf---------->sheet/*.pdf--------->build/*.pdf
 #              1                     1..*
-.SUFFIXES: .dxf
+.SUFFIXES: .dxf .pdf
 
 # Pattern rule for converting a sheet DXF into a sheet PDF
 {drawing\}.dxf{sheet\}.pdf:
 	dwg2pdf -f -o $@ $<
+
+# Pattern rule for concatenating sheet PDFs
+{sheet\}.pdf{build\}.pdf:
+	pdftk $** cat output $@

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 #MAKEFILE Transform source files into deliverables
 
-docs = $(addprefix build/, \
-	CN1-MFG-001.pdf \
-	CN1-REQ-001.pdf \
-	)
-drawings = $(addprefix build/, \
-	CN1-ASY-001.pdf \
-	CN1-PRT-001.pdf \
-	)
+odir = build
+docs = \
+	$(odir)\CN1-MFG-001.pdf \
+	$(odir)\CN1-REQ-001.pdf
+# drawings = $(addprefix build/, \
+# 	CN1-ASY-001.pdf \
+# 	CN1-PRT-001.pdf \
+# 	)
 
-sheets = $(sort $(patsubst drawing/%,sheet/%,$(patsubst %.dxf,%.pdf,$(wildcard drawing/*.dxf))))
+# sheets = $(sort $(patsubst drawing/%,sheet/%,$(patsubst %.dxf,%.pdf,$(wildcard drawing/*.dxf))))
 
 # *
 # * Office
@@ -19,14 +19,15 @@ sheets = $(sort $(patsubst drawing/%,sheet/%,$(patsubst %.dxf,%.pdf,$(wildcard d
 #                 soffice      1
 # doc/*.od?-------------------->build/*.pdf
 #          1
+.SUFFIXES: .ods .odt
 
 # Spreadsheets
-build/%.pdf: doc/%.ods
-	soffice --convert-to pdf --outdir build/ $^
+{doc\}.ods{$(odir)\}.pdf:
+	soffice --convert-to pdf --outdir $(@D) $<
 
 # Text documents
-build/%.pdf: doc/%.odt
-	soffice --convert-to pdf --outdir build/ $^
+{doc\}.odt{$(odir)\}.pdf:
+	soffice --convert-to pdf --outdir $(@D) $<
 
 # *
 # * Drawings
@@ -37,17 +38,17 @@ build/%.pdf: doc/%.odt
 # drawing/*.dxf---------->sheet/*.pdf--------->build/*.pdf
 #              1                     1..*
 
-# Pattern rule for converting a sheet DXF into a sheet PDF
-sheet/%.pdf: drawing/%.dxf
-	dwg2pdf -f -o $@ $<
+# # Pattern rule for converting a sheet DXF into a sheet PDF
+# sheet/%.pdf: drawing/%.dxf
+# 	dwg2pdf -f -o $@ $<
 
-all: directories $(docs) $(drawings)
+all: directories $(docs)
 
-build/CN1-ASY-001.pdf: $(filter sheet/CN1-ASY-001%,$(sheets))
-	pdftk $^ cat output $@
+# build/CN1-ASY-001.pdf: $(filter sheet/CN1-ASY-001%,$(sheets))
+# 	pdftk $^ cat output $@
 
-build/CN1-PRT-001.pdf: $(filter sheet/CN1-PRT-001%,$(sheets))
-	pdftk $^ cat output $@
+# build/CN1-PRT-001.pdf: $(filter sheet/CN1-PRT-001%,$(sheets))
+# 	pdftk $^ cat output $@
 
 .PHONY: clean directories
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,9 @@ odir = build
 docs = \
 	$(odir)\CN1-MFG-001.pdf \
 	$(odir)\CN1-REQ-001.pdf
-# drawings = $(addprefix build/, \
-# 	CN1-ASY-001.pdf \
-# 	CN1-PRT-001.pdf \
-# 	)
-
-# sheets = $(sort $(patsubst drawing/%,sheet/%,$(patsubst %.dxf,%.pdf,$(wildcard drawing/*.dxf))))
+drawings = \
+	$(odir)\CN1-ASY-001.pdf \
+	$(odir)\CN1-PRT-001.pdf
 
 # *
 # * Office
@@ -37,18 +34,19 @@ docs = \
 #               dwg2pdf  1             pdftk  1
 # drawing/*.dxf---------->sheet/*.pdf--------->build/*.pdf
 #              1                     1..*
+.SUFFIXES: .dxf
 
-# # Pattern rule for converting a sheet DXF into a sheet PDF
-# sheet/%.pdf: drawing/%.dxf
-# 	dwg2pdf -f -o $@ $<
+# Pattern rule for converting a sheet DXF into a sheet PDF
+{drawing\}.dxf{sheet\}.pdf:
+	dwg2pdf -f -o $@ $<
 
-all: directories $(docs)
+all: directories $(docs) $(drawings)
 
-# build/CN1-ASY-001.pdf: $(filter sheet/CN1-ASY-001%,$(sheets))
-# 	pdftk $^ cat output $@
+$(odir)\CN1-ASY-001.pdf: sheet\CN1-ASY-001.pdf
+	pdftk $? cat output $@
 
-# build/CN1-PRT-001.pdf: $(filter sheet/CN1-PRT-001%,$(sheets))
-# 	pdftk $^ cat output $@
+$(odir)\CN1-PRT-001.pdf: sheet\CN1-PRT-001.pdf
+	pdftk $? cat output $@
 
 .PHONY: clean directories
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ drawings = \
 all: directories $(docs) $(drawings)
 
 $(odir)\CN1-ASY-001.pdf: sheet\CN1-ASY-001.pdf
+	pdftk $** cat output $@
 
 $(odir)\CN1-PRT-001.pdf: sheet\CN1-PRT-001.pdf
+	pdftk $** cat output $@
 
 .PHONY: clean directories
 
@@ -29,7 +31,7 @@ sheet:
 	mkdir sheet
 
 # *
-# * Office
+# * Rules of Office Documents
 # *
 # The toolchain only uses soffice and assumes there is one document per PDF:
 #
@@ -47,19 +49,15 @@ sheet:
 	soffice --convert-to pdf --outdir $(@D) $<
 
 # *
-# * Drawings
+# * Rules for Drawings
 # *
 # The toolchain from drawings to built artefact is:
 #
-#               dwg2pdf  1             pdftk  1
-# drawing/*.dxf---------->sheet/*.pdf--------->build/*.pdf
-#              1                     1..*
-.SUFFIXES: .dxf .pdf
+#               dwg2pdf  1           
+# drawing/*.dxf---------->sheet/*.pdf
+#              1
+.SUFFIXES: .dxf
 
 # Pattern rule for converting a sheet DXF into a sheet PDF
 {drawing\}.dxf{sheet\}.pdf:
 	dwg2pdf -f -o $@ $<
-
-# Pattern rule for concatenating sheet PDFs
-{sheet\}.pdf{build\}.pdf:
-	pdftk $** cat output $@

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,28 @@ drawings = \
 	$(odir)\CN1-ASY-001.pdf \
 	$(odir)\CN1-PRT-001.pdf
 
+all: directories $(docs) $(drawings)
+
+$(odir)\CN1-ASY-001.pdf: sheet\CN1-ASY-001.pdf
+	pdftk $? cat output $@
+
+$(odir)\CN1-PRT-001.pdf: sheet\CN1-PRT-001.pdf
+	pdftk $? cat output $@
+
+.PHONY: clean directories
+
+clean:
+	del $(odir)\*.pdf
+	del sheet\*.pdf
+
+directories: $(odir) sheet
+
+$(odir):
+	mkdir $(odir)
+
+sheet:
+	mkdir sheet
+
 # *
 # * Office
 # *
@@ -39,25 +61,3 @@ drawings = \
 # Pattern rule for converting a sheet DXF into a sheet PDF
 {drawing\}.dxf{sheet\}.pdf:
 	dwg2pdf -f -o $@ $<
-
-all: directories $(docs) $(drawings)
-
-$(odir)\CN1-ASY-001.pdf: sheet\CN1-ASY-001.pdf
-	pdftk $? cat output $@
-
-$(odir)\CN1-PRT-001.pdf: sheet\CN1-PRT-001.pdf
-	pdftk $? cat output $@
-
-.PHONY: clean directories
-
-clean:
-	del build\*.pdf
-	del sheet\*.pdf
-
-directories: build sheet
-
-build:
-	mkdir build
-
-sheet:
-	mkdir sheet

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Vous trouverez la liste des matériaux et de la quincaillerie nécessaires au se
 * QCAD Professional pour les dessins techniques;
 * LibreOffice 6.* pour les documents;
 * PDFtk pour manipuler les fichiers PDF;
-* MinGW (mingw32-base-bin 2013072200) pour les outils de développement de base.
+* Visual Studio Build Tools 2019 pour les outils de développement de base.
 
 # Construire les artefacts
-Avec l'environnement de développement correct, il vous suffit de lancer la commande "mingw32-make" depuis une invite de commande cmd.exe à la racine du projet et les documents seront générés dans le répertoire "build".
+Avec l'environnement de développement correct, il vous suffit de lancer la commande "nmake" depuis une invite de commande de développeur pour Visual Studio 2019 ("Developer Command Prompt for VS 2019") à la racine du projet. Les documents seront générés dans le répertoire "build".
 
-En cas d'erreurs "'X' n'est pas reconnu en tant que commande interne ou externe [...]", vérifiez que les exécutables de LibreOffice, QCAD, PDFtk et MinGW sont dans votre PATH.
+En cas d'erreurs "'X' n'est pas reconnu en tant que commande interne ou externe [...]", vérifiez que les exécutables de LibreOffice, QCAD, PDFtk sont dans votre PATH.


### PR DESCRIPTION
Convertit le contenu du Makefile pour être capable d'utiliser nmake plutôt que GNU make.

Comme Visual Studio 2019 est déjà une dépendance pour la programmation des applications de bureau dans d'autres projets, utiliser nmake simplifie l'environnement de développement en supprimant une dépendance avec les outils GNU.